### PR TITLE
Disable prefer-readonly-parameter-types

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -1534,7 +1534,7 @@ function getRules(id) {
 
 		// Requires that function parameters are typed as readonly to prevent accidental mutation of inputs
 		// @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
-		rules["@typescript-eslint/prefer-readonly-parameter-types"] = "error"; // NEW
+		rules["@typescript-eslint/prefer-readonly-parameter-types"] = "off"; // NEW
 
 		// Prefer using type parameter when calling Array#reduce instead of casting
 		// @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.md


### PR DESCRIPTION
It seems to trip over generics, and it was merely a nice-to-have rule.