### PR TITLE
Disable `no-undef` for Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",
-    "eslint": "7.24.0",
+    "eslint": "7.25.0",
     "prettier": "2.2.1",
     "typescript": "4.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "test": "mocha test/*.test.js --timeout 10000 --slow 5000"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "4.22.0",
-    "@typescript-eslint/parser": "4.22.0",
+    "@typescript-eslint/eslint-plugin": "4.22.1",
+    "@typescript-eslint/parser": "4.22.1",
     "eslint": "7.25.0",
     "prettier": "2.2.1",
     "typescript": "4.2.4"

--- a/src/eslint.build.js
+++ b/src/eslint.build.js
@@ -635,7 +635,7 @@ function getRules(id) {
 
 	// Disallow the use of undeclared variables unless mentioned in `/ * global * /` comments
 	// @see https://eslint.org/docs/rules/no-undef
-	rules["no-undef"] = "error";
+	rules["no-undef"] = (id === "typescript") ? "off" : "error";
 
 	// Disallow initializing variables to `undefined`
 	// @see https://eslint.org/docs/rules/no-undef-init

--- a/test/eslint.test.js
+++ b/test/eslint.test.js
@@ -282,7 +282,7 @@ const fixtures = {
 		expected: {
 			legacy: ["no-undef"],
 			commonjs: ["no-undef"],
-			typescript: ["no-undef"]
+			typescript: []
 		},
 		ignored: []
 	},
@@ -299,7 +299,7 @@ const fixtures = {
 		expected: {
 			legacy: ["no-undef"],
 			commonjs: ["no-undef"],
-			typescript: ["no-undef"]
+			typescript: []
 		},
 		ignored: []
 	},
@@ -316,7 +316,7 @@ const fixtures = {
 		expected: {
 			legacy: ["no-undef"],
 			commonjs: ["no-undef"],
-			typescript: ["no-undef"]
+			typescript: []
 		},
 		ignored: ["no-unused-vars", "@typescript-eslint/no-unused-vars"]
 	},
@@ -1525,7 +1525,7 @@ const fixtures = {
 		expected: {
 			legacy: ["no-undef"],
 			commonjs: ["no-undef"],
-			typescript: ["no-undef"]
+			typescript: []
 		},
 		ignored: []
 	},
@@ -1533,7 +1533,7 @@ const fixtures = {
 		expected: {
 			legacy: ["no-undef"],
 			commonjs: ["no-undef"],
-			typescript: ["no-undef"]
+			typescript: []
 		},
 		ignored: []
 	},


### PR DESCRIPTION
Updated dependencies and disabled rule `no-undef` in the Typescript config.

See https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors

