### PR TITLE
Disallow space between tag and `

### DIFF
--- a/src/eslint.build.js
+++ b/src/eslint.build.js
@@ -1112,7 +1112,7 @@ function getRules(id) {
 
 	// Require or disallow spacing between template tags and their literals
 	// @see https://eslint.org/docs/rules/template-tag-spacing
-	rules["template-tag-spacing"] = (id === "legacy") ? "off" : ["error", "always"]; // NEW commonjs was off
+	rules["template-tag-spacing"] = (id === "legacy") ? "off" : ["error", "never"]; // NEW commonjs was off
 
 	// Require or disallow Unicode byte order mark (BOM)
 	// @see https://eslint.org/docs/rules/unicode-bom

--- a/test/eslint.test.js
+++ b/test/eslint.test.js
@@ -1569,6 +1569,23 @@ const fixtures = {
 			typescript: []
 		},
 		ignored: ["no-unused-vars", "@typescript-eslint/explicit-function-return-type", "@typescript-eslint/no-unused-vars"]
+	},
+
+	"tag_with_space.js": {
+		expected: {
+			legacy: ["fatal"],
+			commonjs: ["template-tag-spacing"],
+			typescript: ["template-tag-spacing"]
+		},
+		ignored: ["no-undef"]
+	},
+	"tag_without_space.js": {
+		expected: {
+			legacy: ["fatal"],
+			commonjs: [],
+			typescript: []
+		},
+		ignored: ["no-undef"]
 	}
 };
 

--- a/test/eslint/tag_with_space.js
+++ b/test/eslint/tag_with_space.js
@@ -1,0 +1,2 @@
+"use strict";
+const _myvar = mytag `hello`;

--- a/test/eslint/tag_without_space.js
+++ b/test/eslint/tag_without_space.js
@@ -1,0 +1,2 @@
+"use strict";
+const _myvar = mytag`hello`;

--- a/test/prettier.test.js
+++ b/test/prettier.test.js
@@ -157,6 +157,11 @@ const fixtures = {
 		ext: "js",
 		ignore: ["no-mixed-operators", "no-undef", "no-var", "no-unused-vars", "@typescript-eslint/no-unused-vars"],
 		compatible: ["legacy", "commonjs", "typescript"]
+	},
+	tag: {
+		ext: "js",
+		ignore: ["no-undef"],
+		compatible: ["commonjs", "typescript"]
 	}
 };
 

--- a/test/prettier/tag/expected.js
+++ b/test/prettier/tag/expected.js
@@ -1,0 +1,3 @@
+"use strict";
+const _myvar1 = mytag`hello`;
+const _myvar2 = mytag`hello`;

--- a/test/prettier/tag/source.js
+++ b/test/prettier/tag/source.js
@@ -1,0 +1,3 @@
+"use strict";
+const _myvar1 = mytag`hello`;
+const _myvar2 = mytag `hello`;


### PR DESCRIPTION
Switched `template-tag-spacing` from `always` to `never` to match Prettier.

See:
 - https://eslint.org/docs/rules/template-tag-spacing
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals