### PR TITLE
ES2022 parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 This generates packages for the following [Eslint configs](https://eslint.org/docs/developer-guide/shareable-configs):
  - [@wildpeaks/legacy](https://www.npmjs.com/package/@wildpeaks/eslint-config-legacy) for ES5 Javascript projects without modules
  - [@wildpeaks/commonjs](https://www.npmjs.com/package/@wildpeaks/eslint-config-commonjs) for ES2018 Javascript projects using CommonJS modules
- - [@wildpeaks/esmodules](https://www.npmjs.com/package/@wildpeaks/eslint-config-esmodules) for ES2020 Javascript projects using ES Modules
- - [@wildpeaks/typescript](https://www.npmjs.com/package/@wildpeaks/eslint-config-typescript) for ES2020 Typescript projects using ES Modules
+ - [@wildpeaks/esmodules](https://www.npmjs.com/package/@wildpeaks/eslint-config-esmodules) for ES2022 Javascript projects using ES Modules
+ - [@wildpeaks/typescript](https://www.npmjs.com/package/@wildpeaks/eslint-config-typescript) for ES2022 Typescript projects using ES Modules
 
 And the matching [Prettier config](https://prettier.io/docs/en/configuration.html#sharing-configurations):
  - [@wildpeaks/prettier-config](https://www.npmjs.com/package/@wildpeaks/prettier-config)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@typescript-eslint/eslint-plugin": "5.5.0",
     "@typescript-eslint/parser": "5.5.0",
     "eslint": "8.4.0",
-    "prettier": "2.5.0",
+    "prettier": "2.5.1",
     "typescript": "4.5.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "5.5.0",
     "@typescript-eslint/parser": "5.5.0",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "prettier": "2.5.0",
     "typescript": "4.5.2"
   },

--- a/src/eslint.build.js
+++ b/src/eslint.build.js
@@ -1741,14 +1741,14 @@ describe("Typescript", function () {
 			folder,
 			name,
 			title: "Typescript",
-			description: "Settings for **ES2020 Typescript** projects using **ES Modules**.\n\nThis is best suited for **compiled projects** (e.g. Webpack)."
+			description: "Settings for **ES2022 Typescript** projects using **ES Modules**.\n\nThis is best suited for **compiled projects** (e.g. Webpack)."
 		});
 	});
 	it("package.json", function () {
 		writePackage({
 			folder,
 			name,
-			description: "ESLint config for ES2020 Typescript projects using ES Modules",
+			description: "ESLint config for ES2022 Typescript projects using ES Modules",
 			dependencies: ["@typescript-eslint/eslint-plugin", "@typescript-eslint/parser"]
 		});
 	});
@@ -1794,14 +1794,14 @@ describe("ES Modules", function () {
 			folder,
 			name,
 			title: "ES Modules",
-			description: "Settings for **ES2020 Javascript** projects using **ES Modules**.\n\nThis is best suited for **non-transpiled MJS and ESM scripts**."
+			description: "Settings for **ES2022 Javascript** projects using **ES Modules**.\n\nThis is best suited for **non-transpiled MJS and ESM scripts**."
 		});
 	});
 	it("package.json", function () {
 		writePackage({
 			folder,
 			name,
-			description: "ESLint config for ES2020 Javascript projects using ES Modules"
+			description: "ESLint config for ES2022 Javascript projects using ES Modules"
 		});
 	});
 	it("index.js", function () {

--- a/src/eslint.build.js
+++ b/src/eslint.build.js
@@ -1758,7 +1758,7 @@ describe("Typescript", function () {
 			config: {
 				env: {
 					commonjs: true,
-					es2020: true
+					es2021: true
 				},
 				globals: {
 					module: true
@@ -1766,7 +1766,7 @@ describe("Typescript", function () {
 				plugins: ["@typescript-eslint"],
 				parser: "@typescript-eslint/parser",
 				parserOptions: {
-					ecmaVersion: 2020,
+					ecmaVersion: 2022,
 					ecmaFeatures: {
 						jsx: true,
 						impliedStrict: true
@@ -1809,13 +1809,13 @@ describe("ES Modules", function () {
 			folder,
 			config: {
 				env: {
-					es2020: true
+					es2021: true
 				},
 				globals: {
 					module: true
 				},
 				parserOptions: {
-					ecmaVersion: 2020,
+					ecmaVersion: 2022,
 					ecmaFeatures: {
 						impliedStrict: true
 					},

--- a/src/template.prettier.md
+++ b/src/template.prettier.md
@@ -30,6 +30,6 @@ or in `.prettierrc`:
 This is compatible with the following Eslint configs:
  - [@wildpeaks/legacy](https://www.npmjs.com/package/@wildpeaks/eslint-config-legacy) for ES5 Javascript projects without modules
  - [@wildpeaks/commonjs](https://www.npmjs.com/package/@wildpeaks/eslint-config-commonjs) for ES2018 Javascript projects using CommonJS modules
- - [@wildpeaks/esmodules](https://www.npmjs.com/package/@wildpeaks/eslint-config-esmodules) for ES2020 Javascript projects using ES Modules
- - [@wildpeaks/typescript](https://www.npmjs.com/package/@wildpeaks/eslint-config-typescript) for ES2020 Typescript projects using ES Modules
+ - [@wildpeaks/esmodules](https://www.npmjs.com/package/@wildpeaks/eslint-config-esmodules) for ES2022 Javascript projects using ES Modules
+ - [@wildpeaks/typescript](https://www.npmjs.com/package/@wildpeaks/eslint-config-typescript) for ES2022 Typescript projects using ES Modules
 

--- a/src/template.prettier.md
+++ b/src/template.prettier.md
@@ -30,5 +30,6 @@ or in `.prettierrc`:
 This is compatible with the following Eslint configs:
  - [@wildpeaks/legacy](https://www.npmjs.com/package/@wildpeaks/eslint-config-legacy) for ES5 Javascript projects without modules
  - [@wildpeaks/commonjs](https://www.npmjs.com/package/@wildpeaks/eslint-config-commonjs) for ES2018 Javascript projects using CommonJS modules
+ - [@wildpeaks/esmodules](https://www.npmjs.com/package/@wildpeaks/eslint-config-esmodules) for ES2020 Javascript projects using ES Modules
  - [@wildpeaks/typescript](https://www.npmjs.com/package/@wildpeaks/eslint-config-typescript) for ES2020 Typescript projects using ES Modules
 

--- a/test/eslint.test.js
+++ b/test/eslint.test.js
@@ -90,184 +90,184 @@ const fixtures = {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_static_property_without_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 
 	"class_stage2_instance_function_without_return_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_static_function_without_return_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_instance_arrow_without_return_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_static_arrow_without_return_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_instance_expression_without_return_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_static_expression_without_return_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 
 	"class_stage2_instance_function_without_params_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: ["class-methods-use-this"],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars", "class-methods-use-this"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_static_function_without_params_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_instance_arrow_without_params_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: ["class-methods-use-this"],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars", "class-methods-use-this"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_static_arrow_without_params_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_instance_expression_without_params_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: ["class-methods-use-this"],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars", "class-methods-use-this"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_static_expression_without_params_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 
 	"class_stage2_instance_function_underscore_params_without_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: ["class-methods-use-this"],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars", "class-methods-use-this"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_static_function_underscore_params_without_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_instance_arrow_underscore_params_without_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: ["class-methods-use-this"],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars", "class-methods-use-this"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_static_arrow_underscore_params_without_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_instance_expression_underscore_params_without_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: ["class-methods-use-this"],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars", "class-methods-use-this"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 	"class_stage2_static_expression_underscore_params_without_type.js": {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: ["@typescript-eslint/explicit-member-accessibility", "@typescript-eslint/no-unused-vars"]
 		},
-		ignored: []
+		ignored: ["no-unused-vars"]
 	},
 
 	"line_80.js": {
@@ -397,7 +397,7 @@ const fixtures = {
 		expected: {
 			legacy: ["fatal"],
 			commonjs: ["fatal"],
-			esmodules: ["fatal"],
+			esmodules: [],
 			typescript: []
 		},
 		ignored: ["no-unused-vars", "@typescript-eslint/no-unused-vars"]


### PR DESCRIPTION
This bumps `parserOptions.ecmaVersion` to 2022 and uses `env.es2021` (`env.2022` doesn't seem recognized yet) for configs `esmodules` and `typescript`.

This way, config `esmodules` no longer throws a syntax error on toplevel await.

This closes #339.